### PR TITLE
Include license files in cargo package

### DIFF
--- a/trait-transformer/LICENSE-APACHE
+++ b/trait-transformer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/trait-transformer/LICENSE-MIT
+++ b/trait-transformer/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/trait-variant/LICENSE-APACHE
+++ b/trait-variant/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/trait-variant/LICENSE-MIT
+++ b/trait-variant/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This is a cherry-pick of https://github.com/rust-lang/impl-trait-utils/pull/36 to also include the LICENSE-APACHE and LICENSE-MIT files in the cargo package. If this is acceptable, would it be possible to cut a new version 0.1.1 of trait-make to include it?